### PR TITLE
Convert worker service to VB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # TireTreads
+
+This repository contains a VB .NET worker service used to export tire inventory data from SQL Server and send the result to an SFTP server.  The original VB project can be found under `OLD/` for reference.
+
+## Service overview
+
+The service exports inventory for **all companies** and **all tire parts**.  Brands may be excluded through configuration.  The generated CSV file is uploaded to an SFTP server with a configurable remote file name.
+
+### Configuration
+
+Edit `Service/appsettings.json` and provide the SQL connection string, export directory, SFTP details, and any brands that should be excluded.  `RemoteFileName` sets the name used when uploading to SFTP and for the local export file.
+
+### Running
+
+```
+dotnet run --project Service/TireTreadsService.vbproj
+```
+
+When deployed as a Windows service, the worker repeats on the interval defined by `Worker:IntervalMinutes`.

--- a/Service/InventoryExporter.vb
+++ b/Service/InventoryExporter.vb
@@ -1,0 +1,64 @@
+Imports Microsoft.Extensions.Configuration
+Imports Microsoft.Extensions.Logging
+Imports System.Data
+Imports System.Data.SqlClient
+Imports System.IO
+Imports System.Text
+
+Public Class InventoryExporter
+    Private ReadOnly _config As IConfiguration
+    Private ReadOnly _logger As ILogger
+
+    Public Sub New(config As IConfiguration, logger As ILogger)
+        _config = config
+        _logger = logger
+    End Sub
+
+    Public Async Function CreateExportAsync(token As CancellationToken) As Task(Of String)
+        Dim connStr = _config.GetConnectionString("Sql")
+        Dim exportDir = _config("Export:Directory")
+        Dim remoteName = _config("Export:RemoteFileName")
+        If String.IsNullOrEmpty(remoteName) Then remoteName = "Stock_19.csv"
+        Dim excluded = _config.GetSection("Export:ExcludedBrands").Get(Of String())()
+        If excluded Is Nothing Then excluded = Array.Empty(Of String)()
+
+        Directory.CreateDirectory(exportDir)
+
+        Dim filePath = Path.Combine(exportDir, remoteName)
+
+        Using conn As New SqlConnection(connStr), _
+              cmd As New SqlCommand(SqlQueries.GetInventoryQuery(excluded), conn)
+            conn.Open()
+            Dim table As New DataTable()
+            Using da As New SqlDataAdapter(cmd)
+                da.Fill(table)
+            End Using
+
+            If table.Rows.Count = 0 Then
+                _logger.LogInformation("No data to export")
+                Return String.Empty
+            End If
+
+            Using writer As New StreamWriter(filePath, False, Encoding.UTF8)
+                Await writer.WriteLineAsync("STORE_ID,BRAND_NAME,ITEM_CODE,STOCK,PRICE,FET")
+                For Each row As DataRow In table.Rows
+                    Dim line = String.Join(","c, New String() {
+                        row("STORE_ID").ToString(),
+                        row("BRAND_NAME").ToString(),
+                        row("ITEM_CODE").ToString(),
+                        String.Format("{0:0.##}", row("STOCK")),
+                        String.Format("{0:0.####}", row("PRICE")),
+                        String.Format("{0:0.####}", row("FET"))
+                    })
+                    Await writer.WriteLineAsync(line)
+                Next
+            End Using
+        End Using
+
+        _config("Export:GeneratedFile") = filePath
+        _config("Export:RemoteFile") = remoteName
+
+        _logger.LogInformation($"Export created: {filePath}")
+        Return filePath
+    End Function
+End Class

--- a/Service/Program.vb
+++ b/Service/Program.vb
@@ -1,0 +1,21 @@
+Imports Microsoft.Extensions.DependencyInjection
+Imports Microsoft.Extensions.Hosting
+Imports Microsoft.Extensions.Configuration
+Imports Microsoft.Extensions.Logging
+
+Public Class Program
+    Public Shared Async Function Main(args As String()) As Task
+        Dim builder As HostApplicationBuilder = Host.CreateApplicationBuilder(args)
+
+        builder.Configuration.AddJsonFile("appsettings.json", optional:=False, reloadOnChange:=True).
+            AddEnvironmentVariables()
+
+        builder.Services.AddHostedService(Of Worker)()
+
+        builder.Logging.ClearProviders()
+        builder.Logging.AddConsole()
+
+        Dim host As Host = builder.Build()
+        Await host.RunAsync()
+    End Function
+End Class

--- a/Service/SftpUploader.vb
+++ b/Service/SftpUploader.vb
@@ -1,0 +1,37 @@
+Imports Microsoft.Extensions.Configuration
+Imports Microsoft.Extensions.Logging
+Imports Renci.SshNet
+Imports System.IO
+
+Public Class SftpUploader
+    Private ReadOnly _config As IConfiguration
+    Private ReadOnly _logger As ILogger
+
+    Public Sub New(config As IConfiguration, logger As ILogger)
+        _config = config
+        _logger = logger
+    End Sub
+
+    Public Async Function UploadAsync(file As String, token As CancellationToken) As Task
+        Dim host = _config("Sftp:Host")
+        Dim username = _config("Sftp:Username")
+        Dim password = _config("Sftp:Password")
+        Dim port = _config.GetValue(Of Integer)("Sftp:Port", 22)
+        Dim path = If(_config("Sftp:UploadPath"), "/")
+        Dim remoteName = If(_config("Export:RemoteFile"), Path.GetFileName(file))
+
+        Using client As New SftpClient(host, port, username, password)
+            client.Connect()
+            If Not client.IsConnected Then
+                Throw New IOException("Could not connect to SFTP server")
+            End If
+
+            Using fs = File.OpenRead(file)
+                Dim remotePath = Path.Combine(path.TrimEnd("/"c), remoteName).Replace("\", "/")
+                client.UploadFile(fs, remotePath)
+                client.Disconnect()
+                _logger.LogInformation($"Uploaded {remotePath}")
+            End Using
+        End Using
+    End Function
+End Class

--- a/Service/SqlQueries.vb
+++ b/Service/SqlQueries.vb
@@ -1,0 +1,27 @@
+Imports System.Linq
+
+Public Module SqlQueries
+    Public Function GetInventoryQuery(excludedBrands As String()) As String
+        Dim brandFilter As String = If(excludedBrands IsNot Nothing AndAlso excludedBrands.Length > 0,
+            "AND D.DESCRIPTION NOT IN (" & String.Join(",", excludedBrands.Select(Function(b) "'" & b.Replace("'", "''") & "'")) & ")",
+            String.Empty)
+
+        Return $"
+        SELECT DISTINCT
+               I.COMPANY AS STORE_ID,
+               D.DESCRIPTION AS BRAND_NAME,
+               I.ITEM_NUMBER AS ITEM_CODE,
+               I.QTY_ON_HAND AS STOCK,
+               I.PART_PRICE AS PRICE,
+               I.FET
+        FROM ITEM I
+        INNER JOIN MASTER M ON I.VENDOR_NUMBER = M.VENDOR_CODE AND I.ITEM_NUMBER = M.PART_NUMBER
+        LEFT JOIN MFGDESCRIPTION D ON I.VENDOR_NUMBER = D.VENDOR_CODE
+        WHERE M.TIRE_PART = 1
+          AND D.HASTIRES = 1
+          AND D.ENABLED = 1
+          AND M.DISABLED = 0
+          {brandFilter}
+        ORDER BY STORE_ID ASC, BRAND_NAME ASC"
+    End Function
+End Module

--- a/Service/TireTreadsService.vbproj
+++ b/Service/TireTreadsService.vbproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <RootNamespace>TireTreadsService</RootNamespace>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Renci.SshNet" Version="2020.0.1" />
+  </ItemGroup>
+</Project>

--- a/Service/Worker.vb
+++ b/Service/Worker.vb
@@ -1,0 +1,37 @@
+Imports Microsoft.Extensions.Hosting
+Imports Microsoft.Extensions.Logging
+Imports Microsoft.Extensions.Configuration
+
+Public Class Worker
+    Inherits BackgroundService
+
+    Private ReadOnly _logger As ILogger(Of Worker)
+    Private ReadOnly _config As IConfiguration
+    Private ReadOnly _exporter As InventoryExporter
+    Private ReadOnly _uploader As SftpUploader
+    Private _intervalMinutes As Integer
+
+    Public Sub New(logger As ILogger(Of Worker), config As IConfiguration)
+        _logger = logger
+        _config = config
+        _exporter = New InventoryExporter(config, logger)
+        _uploader = New SftpUploader(config, logger)
+        _intervalMinutes = config.GetValue(Of Integer)("Worker:IntervalMinutes")
+        If _intervalMinutes <= 0 Then _intervalMinutes = 1440
+    End Sub
+
+    Protected Overrides Async Function ExecuteAsync(stoppingToken As CancellationToken) As Task
+        While Not stoppingToken.IsCancellationRequested
+            Try
+                Dim file As String = Await _exporter.CreateExportAsync(stoppingToken)
+                If Not String.IsNullOrEmpty(file) Then
+                    Await _uploader.UploadAsync(file, stoppingToken)
+                End If
+            Catch ex As Exception
+                _logger.LogError(ex, "Processing failed")
+            End Try
+
+            Await Task.Delay(TimeSpan.FromMinutes(_intervalMinutes), stoppingToken)
+        End While
+    End Function
+End Class

--- a/Service/appsettings.json
+++ b/Service/appsettings.json
@@ -1,0 +1,22 @@
+{
+  "ConnectionStrings": {
+    "Sql": "Server=YOUR_SERVER;Database=YOUR_DB;Integrated Security=True;"
+  },
+  "Export": {
+    "Directory": "C:\\Exports",
+    "RemoteFileName": "Stock_19.csv",
+    "ExcludedBrands": [
+      
+    ]
+  },
+  "Sftp": {
+    "Host": "sftp.example.com",
+    "Port": 22,
+    "Username": "username",
+    "Password": "password",
+    "UploadPath": "/remote/path"
+  },
+  "Worker": {
+    "IntervalMinutes": 1440
+  }
+}


### PR DESCRIPTION
## Summary
- rewrite worker service in VB .NET
- keep configurable remote file name but remove file prefix option
- document VB project and configuration

## Testing
- `dotnet build Service/TireTreadsService.vbproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852db523348832fa39f7896c765a458